### PR TITLE
Change the output format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM bentoml/model-server:0.11.0-py310
 MAINTAINER ersilia
 
 
-RUN pip install git+https://github.com/MolecularAI/REINVENT4 --extra-index-url=https://pypi.anaconda.org/OpenEye/simple --extra-index-url https://download.pytorch.org/whl/cu113
-
-RUN pip install rdkit
+RUN pip install rdkit-pypi==2022.9.5
+RUN pip install protobuf==3.18.3
+RUN pip install tensorboardx==2.0
 RUN pip install chemprop==1.5.2
 RUN pip install tensorboard==2.11.0
-RUN pip install tensorboardx==2.1
+
+RUN pip install git+https://github.com/MolecularAI/REINVENT4 --extra-index-url=https://pypi.anaconda.org/OpenEye/simple --extra-index-url https://download.pytorch.org/whl/cu113
+
 
 WORKDIR /repo
 COPY . /repo

--- a/model/framework/code/main.py
+++ b/model/framework/code/main.py
@@ -54,13 +54,14 @@ output_len = len(outputs)
 assert input_len == output_len
 
 
-HEADER = [f"smi_{x}" for x in range(num_input_smiles * batch_size)]
+HEADER = [f"smi_{x}" for x in range(batch_size)]
 
 with open(output_file, "w", newline="") as fp:
     csv_writer = csv.writer(fp)
     # First Row: Header
-    # Second Row: Generated Smiles (Output)
-    csv_writer.writerows([HEADER, flatten_outputs])
+    # Second Row onwards: Generated Smiles (Output)
+    csv_writer.writerows([HEADER])
+    csv_writer.writerows(outputs)
 
 
 if is_debug:


### PR DESCRIPTION
When I change the output format, then `ersilia -v fetch eos694w --repo_path .` works.

Previously, the output format was:

```
[header]
[all the output of first input] + [all the output of second input] +.. + [all the output of nth input]
```

We were merging all the output in a single row.

Now, I am writing all the outputs in a new lines.

```
[header]
[all the output of first input]
[all the output of second input]
.
.
.
[all the output of nth input]
```